### PR TITLE
lsコマンドに`-a`オプションの追加 ＆ マルチバイト文字に対応

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -44,7 +44,7 @@ end
 
 # 「マルチバイト文字1文字 = 半角文字2文字」として文字列の長さをカウントする
 def size_for_multibyte_characters(string)
-  string.each_char.map { |c| c.bytesize == 1 ? 1 : 2 }.inject(:+)
+  string.each_char.map { |c| c.bytesize == 1 ? 1 : 2 }.sum
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,15 +24,27 @@ def print_all_files(all_files)
 
   (0...num_rows).each do |row|
     subset_files = all_files.select.each_with_index { |_, i| i % num_rows == row }
-    puts subset_files.each_with_index.map { |file, i| file.ljust(widths_per_column[i]) }.join
+    puts subset_files.each_with_index.map { |file, i| ljust_for_multibyte_characters(file, widths_per_column[i]) }.join
   end
 end
 
 # 出力時の幅を列毎に計算する
 def calculation_width_columns(all_files, num_rows)
   all_files.each_slice(num_rows).map do |files|
-    files.map(&:size).max + WIDTH_BETWEEN_COLUMNS
+    files.map { |file| size_for_multibyte_characters(file) }.max + WIDTH_BETWEEN_COLUMNS
   end
+end
+
+# マルチバイト文字を考慮して左詰めした文字列を返す
+def ljust_for_multibyte_characters(string, width, padding = ' ')
+  multibyte_width = size_for_multibyte_characters(string)
+  padding_size = [0, width - multibyte_width].max
+  string + padding * padding_size
+end
+
+# 「マルチバイト文字1文字 = 半角文字2文字」として文字列の長さをカウントする
+def size_for_multibyte_characters(string)
+  string.each_char.map { |c| c.bytesize == 1 ? 1 : 2 }.inject(:+)
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
+require 'optparse'
+
 NUMBER_OF_COLUMNS = 3
 WIDTH_BETWEEN_COLUMNS = 2
 
 def main
-  all_files = glob_and_sort_files
+  options = ARGV.getopts('a')
+  all_files = glob_and_sort_files(options['a'])
   print_all_files(all_files)
 end
 
 # lsコマンド同様の並び順で、ファイルの配列を取得する
-def glob_and_sort_files
-  all_files = Dir.glob('*')
+def glob_and_sort_files(is_all)
+  all_files = is_all ? Dir.entries('.') : Dir.glob('*')
   all_files.sort! { |x, y| x.casecmp(y).nonzero? || y <=> x }
 end
 


### PR DESCRIPTION
`ls.rb`に対し、以下の機能追加をしました。

- 隠しファイルを表示する`-a`オプションの追加（「lsコマンドを作る2」の課題）
- マルチバイト文字を含むファイル名に対応（歓迎要件）

レビューをお願いします🙇